### PR TITLE
Fix amqp gem version to 1.5.3

### DIFF
--- a/omf_ec/Gemfile
+++ b/omf_ec/Gemfile
@@ -12,7 +12,7 @@ end
 gem 'rake'
 gem 'omf_common', override_with_local(path: '../../omf6/omf_common', version: "~> 6.2.0.pre")
 gem 'omf_ec', override_with_local(path: '../../omf6/omf_ec', version: "~> 6.2.0.pre")
-gem 'amqp'
+gem 'amqp', '= 1.5.3'
 gem 'json-jwt'
 gem 'pg'
 

--- a/test/omf_rc/Gemfile
+++ b/test/omf_rc/Gemfile
@@ -12,7 +12,7 @@ end
 gem 'omf_common', override_with_local(path: '../../../omf6/omf_common', version: "~> 6.1.0")
 gem 'omf_rc', override_with_local(path: '../../../omf6/omf_rc', version: "~> 6.1.0")
 
-gem 'amqp'
+gem 'amqp', '= 1.5.3'
 gem 'json-jwt'
 gem 'oml4r'
 


### PR DESCRIPTION
- Versions 1.6.0 and later require Ruby 2.0.0 or greater, and break the
  current setup
- Fixes #1
